### PR TITLE
CI for deployment to Azure: fix venv

### DIFF
--- a/.github/workflows/azure-webapps-python.yml
+++ b/.github/workflows/azure-webapps-python.yml
@@ -39,9 +39,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: python-app
-          path: |
-            .
-            !venv/
+          path: .
 
   deploy:
     permissions:


### PR DESCRIPTION
This merge changes the GitHub Actions configuration file to include `venv/` directory in the deploy process.

 The default pipeline excludes `venv/` directory during the deployment, which assumes that `SCM_DO_BUILD_DURING_DEPLOYMENT` is set to `true` in Web App Service. However, since the build includes an additional update to `SQLAlchemy`, the environment created on Web App Services is inconsistent. See https://github.com/UNDP-Data/dsc-energy-ai-backend/issues/9.

While including `venv/` directory should fix the issue, this is a **temporary fix** that needs to be eventually resolved by modifying resolving dependency issues in `requirements.txt`.